### PR TITLE
[SETTING] 헤더에 자동으로 토큰 붙여서 전송 세팅

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,20 @@
+import axios from 'axios'
+import { useUserStore } from '@/stores/userStore'
+
+const api = axios.create({
+    timeout: 5000
+})
+
+api.interceptors.request.use(
+    config => {
+        const accessToken = sessionStorage.getItem('accessToken')
+        console.log(accessToken);
+        if (accessToken) {
+            config.headers.Authorization = `Bearer ${accessToken}`
+        }
+        return config
+    },
+    error => Promise.reject(error)
+)
+
+export default api


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> api 요청 시 axios 대신 사용하여 토큰을 헤더에 넣어가도록 설정

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> setting/sw/api

## 📂 관련 이슈 (Issue)
- close #7 

## 💡 추가 설명 (Additional Info)
axios 대신 api.js를 추가하여 전송시에 accessToken을 자동으로 넣어주도록 설정하였습니다.

컴포넌트에선 import axios from 'axios' 대신 import api from '@/api'를 사용하면 되며 헤더부분 설정하는 부분에 토큰을 넣지 않아도 토큰을 넣어줍니다.

예시)
![image](https://github.com/user-attachments/assets/149a27b0-85f9-4887-8920-53dd8e214902)
