### PR TITLE
[REFACTOR] 리프레시 토큰을 쿠키 방식으로 변경

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -2,8 +2,23 @@ import axios from 'axios'
 import { useUserStore } from '@/stores/userStore'
 
 const api = axios.create({
-    timeout: 50000
+    timeout: 50000,
+    withCredentials: true
 })
+
+let isRefreshing = false
+let failedQueue = []
+
+const processQueue = (error, token = null) => {
+    failedQueue.forEach(({ resolve, reject }) => {
+        if (token) {
+            resolve(token)
+        } else {
+            reject(error)
+        }
+    })
+    failedQueue = []
+}
 
 api.interceptors.request.use(
     config => {
@@ -16,5 +31,50 @@ api.interceptors.request.use(
     },
     error => Promise.reject(error)
 )
+
+api.interceptors.response.use(response => response, async error => {
+    const originalRequest = error.config
+    const userStore = useUserStore()
+    
+    if (error.response?.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true
+
+        if (isRefreshing) {
+            return new Promise((resolve, reject)=> {
+                failedQueue.push({
+                    resolve: (token) => {
+                        originalRequest.headers.Authorization = `Bearer ${token}`
+                        resolve(api(originalRequest))
+                    },
+                    reject
+                })
+            })
+        }
+            
+        isRefreshing = true
+
+        try {
+            const res = await api.post('/api/auth/reissue', {
+                userId: userStore.id,
+                companySchema: userStore.schemaName
+            })
+
+            const newToken = res.data.data.accessToken
+            userStore.setAccessToken(newToken)
+
+            processQueue(null, newToken)
+
+            originalRequest.headers.Authorization = `Bearer ${newToken}`
+            return api(originalRequest)
+        } catch (error) {
+            processQueue(error, null)
+            console.log('에러', error)
+            return Promise.reject(error)
+        } finally {
+            isRefreshing = false
+        }
+    }
+    return Promise.reject(error)
+})
 
 export default api

--- a/src/components/common/TheHeader.vue
+++ b/src/components/common/TheHeader.vue
@@ -6,7 +6,7 @@
       </router-link>
     </div>
 
-    <nav class="nav">
+    <nav class="nav" v-if="isMaster">
       <router-link to="/">프로젝트</router-link>
       <router-link to="/template">템플릿</router-link>
       <router-link to="/calendar">부서 일정</router-link>
@@ -52,7 +52,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useUserStore } from '@/stores/userStore'
 import { useNotificationStore } from '@/stores/notificationStore'
@@ -80,6 +80,10 @@ const showDropdown = ref({ user: false })
 
 const userBox = ref(null)
 const isAdmin = ref(userStore.roles?.includes('ADMIN') ?? false)
+
+const isMaster = computed(() => {
+  return localStorage.getItem("schemaName") !== 'master'
+})
 
 const triggerFileInput = () => fileInput.value?.click()
 

--- a/src/components/user/LoginModal.vue
+++ b/src/components/user/LoginModal.vue
@@ -161,7 +161,11 @@
                 // 임시 비번 변경 모달창
             ]
             await nextTick();
-            router.push('/');
+            if (localStorage.getItem("schemaName") !== 'master') {
+                router.push('/');
+            } else {
+                router.push('/master')
+            }
         } catch (error) {
             if (error.response) {
             console.error('에러 응답:', error.response.data);

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -140,6 +140,13 @@ const routes = [
     path: '/task/:taskId',
     name: 'TaskDetail',
     component: () => import('@/views/task/TaskDetail.vue')
+  },
+
+  // erp_master
+  {
+    path: '/master',
+    name: 'MasterPage',
+    component: () => import('@/views/master/ErpMaster.vue')
   }
 ]
 
@@ -150,14 +157,27 @@ const router = createRouter({
 
 router.beforeEach(async (to, from, next) => {
   const userStore = useUserStore()
+  const schema = localStorage.getItem('schemaName')
 
-  if (to.path === '/admin') {
+  if (to.path.startsWith('/admin')) {
     const hasAdminRole = userStore.roles.includes('ADMIN')
     if (!hasAdminRole) {
       alert('관리자만 접근할 수 있습니다.')
       return next('/')
     }
   }
+
+  // master 전용 페이지 접근 제한
+  if (to.path.startsWith('/master') && schema !== 'master') {
+    alert('master 전용 페이지입니다.')
+    return next('/')
+  }
+
+  if (schema === 'master' && !to.path.startsWith('/master')) {
+    alert('master 계정은 이 페이지에 접근할 수 없습니다.')
+    return next('/master')
+  }
+
   next()
 })
 

--- a/src/stores/userStore.js
+++ b/src/stores/userStore.js
@@ -21,8 +21,6 @@ export const useUserStore = defineStore('user', () => {
     const roles = ref([])
 
     const forcedLogout = ref(false)
-    // const isLoggedIn = computed(() => !!id.value)
-    const refreshToken = ref(null)
     const schemaName = ref(null)
     // 로그인 상태 판단
     const isLoggedIn = computed(() =>
@@ -47,7 +45,6 @@ export const useUserStore = defineStore('user', () => {
 
     async function login(responseLogin) {
         accessToken.value = responseLogin.accessToken
-        refreshToken.value = responseLogin.refreshToken
 
         setUserData(responseLogin)
 
@@ -68,7 +65,6 @@ export const useUserStore = defineStore('user', () => {
             jobRoleName: jobRoleName.value,
             roles: roles.value
         }))
-        localStorage.setItem('refreshToken', refreshToken.value)
         localStorage.setItem('schemaName', schemaName.value)
         sessionStorage.setItem('accessToken', accessToken.value)
     }
@@ -107,13 +103,9 @@ export const useUserStore = defineStore('user', () => {
         jobRoleName.value = ''
         roles.value = []
 
-        // isLoggedIn.value = false
-
-        refreshToken.value = null
         schemaName.value = null
 
         localStorage.removeItem('user')
-        localStorage.removeItem('refreshToken')
         sessionStorage.removeItem('accessToken')
         localStorage.removeItem('schemaName')
     }
@@ -121,20 +113,16 @@ export const useUserStore = defineStore('user', () => {
     async function tryReissueToken() {
         const savedUser = localStorage.getItem('user')
         const parsedUser = JSON.parse(savedUser);
-        const refreshToken = localStorage.getItem('refreshToken')
         const schemaName = localStorage.getItem('schemaName')
         
         if (!savedUser || !refreshToken) return
 
         try {
             const response = await axios.post('/api/auth/reissue', {
-                'refreshToken': refreshToken,
-                'userId': parsedUser.id,
-                'companySchema': schemaName
+                userId: parsedUser.id,
+                companySchema: schemaName
             }, {
-                headers: {
-                    'Content-Type': 'application/json'
-                },
+                withCredentials: true
             })
 
             const reissueResponse = response.data.data
@@ -170,6 +158,11 @@ export const useUserStore = defineStore('user', () => {
             return false
         }
     }
+
+    function setAccessToken(token) {
+        accessToken.value = token;
+        sessionStorage.setItem('accessToken', token)
+    }
     
     async function updateUserInfo(userId) {
         console.log('savedUser', userId)
@@ -204,16 +197,14 @@ export const useUserStore = defineStore('user', () => {
 
     async function restoreFromStorage() {
         const savedUser = localStorage.getItem('user')
-        const savedRefreshToken = localStorage.getItem('refreshToken')
         const savedSchemaName = localStorage.getItem('schemaName')
         const savedAccessToken = sessionStorage.getItem('accessToken') // 저장되어 있다면 복원
 
-        if (savedUser && savedRefreshToken) {
+        if (savedUser) {
             const parsedUser = JSON.parse(savedUser)
 
             setUserData(parsedUser)
 
-            refreshToken.value = savedRefreshToken
             schemaName.value = savedSchemaName
             accessToken.value = savedAccessToken
         } else {
@@ -242,7 +233,7 @@ export const useUserStore = defineStore('user', () => {
         restoreFromStorage,
         isLoggedIn,
 
-        refreshToken,
+        setAccessToken,
         schemaName,
         login,
         logout,

--- a/src/views/master/ErpMaster.vue
+++ b/src/views/master/ErpMaster.vue
@@ -1,0 +1,24 @@
+<template>
+    <div class="container">
+        <div class="content">
+            ㅇㅅㅇ
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+</script>
+
+<style scoped>
+    .container {
+        border: 1px solid black;
+        height: calc(100vh - 100px);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+    .content {
+        border: 1px solid black;
+    }
+</style>

--- a/src/views/master/ErpMaster.vue
+++ b/src/views/master/ErpMaster.vue
@@ -1,13 +1,34 @@
 <template>
     <div class="container">
         <div class="content">
-            ㅇㅅㅇ
+            {{ tenantList }}
         </div>
     </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import api from '@/api';
+
+const searchTenant = ref('')
+const tenantList = ref([])
+
+async function fetchTenant() {
+    try {
+        const response = await api.get('/api/tenant/find-all')
+        tenantList.value = response.data.data
+        console.log('tenentList', tenantList.value)
+    } catch (error) {
+        if(error.response) {
+            alert(error.response.data.message)
+        }
+    }
+}
+
+onMounted(() => {
+    fetchTenant()
+})
+
 </script>
 
 <style scoped>


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 리프레시 토큰을 쿠키 방식으로 변경
accessToken이 없이 요청이 전송되었을 경우 자동으로 토큰 재발급 후 다시 요청을 날리도록 api.js 설정

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> refactor/sw/refreshToken

## 📂 관련 이슈 (Issue)
- close #41 

## 💡 추가 설명 (Additional Info)
> api.js를 사용한다면 요청 전송 시 쿠키를 함께 전달하며 액세스 토큰이 없어 401에러가 뜬다면 재발급 후 재요청까지 시도합니다.

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.