### PR TITLE
[FEAT] 알림 읽음처리 및 해당 알림 클릭시 라우팅

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -90,7 +90,7 @@ provide('closeNotificationSidebar', closeNotificationSidebar)
     <TheHeader v-if="route.path !== '/login' && isRestored" />
     <NotificationSidebar />
     <VMain class="main-content">
-      <RouterView />
+      <RouterView  :key="$route.path" />
     </VMain>
   </VApp>
 </template>

--- a/src/components/common/NotificationSidebar.vue
+++ b/src/components/common/NotificationSidebar.vue
@@ -80,8 +80,8 @@ const handleNotificationClick = async (notice) => {
         return;
     }
 
-    // 라우팅 처리 - key를 추가하여 강제로 리렌더링
-    router.push({ path: targetUrl, query: { key: Date.now() } }); // query 파라미터로 key 추가
+   // 라우팅 처리
+  router.push(targetUrl);
   } else {
     console.error("알림 읽기 실패:", response.message || "알 수 없는 오류");
   }

--- a/src/components/common/NotificationSidebar.vue
+++ b/src/components/common/NotificationSidebar.vue
@@ -10,9 +10,9 @@
       </div>
 
       <div class="notification-list">
-        <div v-for="(notice, index) in notifications" :key="index" class="notification-item">
+        <div v-for="(notice, index) in notifications" :key="index" class="notification-item" :class="{ 'read': notice.status === 'READ', 'sent': notice.status === 'SENT' }"  @click="handleNotificationClick(notice)">
           <div class="message">
-            <span v-if="notice.status === 'SENT'" class="new-icon"></span> 
+            <span  class="new-icon"></span> 
             {{ notice.content }}
           </div>
           <div class="date">{{ notice.date }} <!-- 삭제 버튼 추가 -->
@@ -25,13 +25,15 @@
 </template>
 
 <script setup>
-import { defineProps,defineEmits,watch } from 'vue'
+import { defineProps,defineEmits } from 'vue'
+import { useRouter } from 'vue-router'; // vue-router 사용
 import { useUserStore } from '@/stores/userStore'
 import { useNotificationStore } from '@/stores/notificationStore';
 import api from '@/api';
 
   const userStore = useUserStore()
   const notificationStore = useNotificationStore()
+  const router = useRouter(); // router 사용
   const token = userStore.accessToken;
 
 const props = defineProps({
@@ -52,6 +54,68 @@ const emit = defineEmits(['closeSidebar'])
 const closeSidebar = () => {
   emit('closeSidebar')  // 부모 컴포넌트에 closeSidebar 이벤트를 전달
 }
+
+
+// 알림 클릭 시 라우팅과 읽기 처리 함수
+const handleNotificationClick = async (notice) => {
+  // 알림을 읽음 처리
+  const response = await markNotificationAsRead(notice.id);
+  
+  // 읽기 성공시 라우팅
+  if (response.status === 'success') {
+    let targetUrl = '';
+
+    switch (notice.targetType) {
+      case 'TASK':
+        targetUrl = `/task/${notice.targetId}`;
+        break;
+      case 'PROJECT':
+        targetUrl = `/project/${notice.targetId}/overview`;
+        break;
+      case 'APPROVAL':
+        targetUrl = '/approval';
+        break;
+      default:
+        console.error('알 수 없는 targetType:', notice.targetType);
+        return;
+    }
+
+    // 라우팅 처리
+    router.push(targetUrl);
+  } else {
+    console.error("알림 읽기 실패:", response.message || "알 수 없는 오류");
+  }
+}
+
+// 알림을 읽음 처리 API 호출
+const markNotificationAsRead = async (notificationId) => {
+  if (!token) {
+    console.error("토큰이 없습니다. 로그인 상태를 확인해주세요.");
+    return { status: 'fail', message: '로그인 상태가 아닙니다.' };
+  }
+
+  try {
+    const response = await api.patch(`/api/notifications/${notificationId}/read`);
+    
+    if (response.data.status === "success") {
+      // store에서 notifications를 가져와서 상태 업데이트
+      const updatedNotification = notificationStore.notifications.find(notice => notice.id === notificationId);
+      if (updatedNotification) {
+        updatedNotification.status = 'READ'; // 상태 업데이트
+      }
+      console.log("알림이 읽음 상태로 변경되었습니다.");
+      return { status: 'success', message: '알림이 읽음 상태로 변경되었습니다.' };
+    } else {
+      console.error("알림 읽기 실패:", response.data.message || "알 수 없는 오류");
+      return { status: 'fail', message: response.data.message };
+    }
+  } catch (error) {
+    console.error('알림 읽기 오류:', error);
+    return { status: 'error', message: '알림 읽기 처리 중 오류 발생' };
+  }
+}
+
+
 
 // 알림 삭제 함수
 const deleteNotification = async (notificationId, isAutoDelete) => {
@@ -131,6 +195,7 @@ const deleteNotification = async (notificationId, isAutoDelete) => {
   font-size: 14px;
   color: #333;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    cursor: pointer; /* 클릭 가능한 모양으로 변경 */
 }
 
 .notification-item .message {
@@ -144,12 +209,14 @@ const deleteNotification = async (notificationId, isAutoDelete) => {
 .notification-item.sent {
   background-color: #e0f7fa; /* 파란색 계열 강조 색 */
   font-weight: bold;
+  border: 1px solid gray; /* 얇은 검정색 테두리 추가 */
 }
 
 /* READ 상태일 경우 기본 흰색 배경 */
 .notification-item.read {
   background-color: white;
   color: #555;
+  border: 1px solid gray; /* 얇은 검정색 테두리 추가 */
 }
 
 .notification-item .error-icon {

--- a/src/components/common/NotificationSidebar.vue
+++ b/src/components/common/NotificationSidebar.vue
@@ -66,7 +66,7 @@ const handleNotificationClick = async (notice) => {
     let targetUrl = '';
 
     switch (notice.targetType) {
-      case 'TASK':
+      case 'WORK':
         targetUrl = `/task/${notice.targetId}`;
         break;
       case 'PROJECT':
@@ -80,8 +80,8 @@ const handleNotificationClick = async (notice) => {
         return;
     }
 
-    // 라우팅 처리
-    router.push(targetUrl);
+    // 라우팅 처리 - key를 추가하여 강제로 리렌더링
+    router.push({ path: targetUrl, query: { key: Date.now() } }); // query 파라미터로 key 추가
   } else {
     console.error("알림 읽기 실패:", response.message || "알 수 없는 오류");
   }
@@ -207,7 +207,7 @@ const deleteNotification = async (notificationId, isAutoDelete) => {
 
 /* SENT 상태일 경우 강조 색 */
 .notification-item.sent {
-  background-color: #e0f7fa; /* 파란색 계열 강조 색 */
+  background-color: #feefef; /* 파란색 계열 강조 색 */
   font-weight: bold;
   border: 1px solid gray; /* 얇은 검정색 테두리 추가 */
 }

--- a/src/components/common/TheHeader.vue
+++ b/src/components/common/TheHeader.vue
@@ -148,6 +148,8 @@ const fetchNotifications = async () => {
       response.data.data.filter(notice => !notice.isAutoDelete).forEach(notification => {
         store.addNotification(notification)
       })
+      // 최신순으로 알림 목록 정렬
+      store.notifications.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
       const lastNotification = response.data.data[0]
       if (lastNotification) {

--- a/src/components/common/TheHeader.vue
+++ b/src/components/common/TheHeader.vue
@@ -18,6 +18,8 @@
       <!-- 알림 버튼 -->
       <v-btn icon variant="plain" class="ring-btn" @click="openNotificationSidebar">
         <v-icon>mdi-bell-outline</v-icon>
+                <!-- 알림 개수 표시 배지 -->
+        <span v-if="unreadNotificationsCount > 0" class="notification-badge">{{ unreadNotificationsCount }}</span>
       </v-btn>
 
       <!-- 프로필 + 이름 + 화살표 통합 -->
@@ -118,6 +120,11 @@ const handleFileChange = async (event) => {
   }
   reader.readAsDataURL(file)
 }
+
+// 안 읽은 알림 개수 계산
+const unreadNotificationsCount = computed(() => {
+  return notifications.filter(notice => notice.status === 'SENT').length
+})
 
 const openNotificationSidebar = () => {
   notificationSidebarOpen.value = true
@@ -325,5 +332,16 @@ onBeforeUnmount(() => {
   border: none;
   padding: 0;
   color: black;
+}
+
+.notification-badge {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  background-color: red;
+  color: white;
+  border-radius: 50%;
+  padding: 2px 5px;
+  font-size: 12px;
 }
 </style>

--- a/src/components/task/DetailModal.vue
+++ b/src/components/task/DetailModal.vue
@@ -311,6 +311,7 @@ validateForm() {
     });
 
   console.log("최종 유효한 참여자 목록:", validParticipants);
+  console.log("최종 유효한 참여자 목록:",   this.taskDetails.assignees);
 
       const updatedData = {
         name: this.taskDetails.taskName,

--- a/src/stores/notificationStore.js
+++ b/src/stores/notificationStore.js
@@ -18,6 +18,9 @@ export const useNotificationStore = defineStore('notification', () => {
     if (!exists) {
       notifications.value.unshift(notification); 
     }
+
+      // 최신순으로 정렬 (배열에 추가된 후 정렬)
+  notifications.value.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
   };
 
     // 알림의 isAutoDelete가 true로 바뀌었을 때 배열에서 제거하는 함수


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)

알림 읽음처리 및 해당 알림 클릭시 라우팅,

안 읽은 알림 개수도 헤더의 종모양 위에 뜨게 됩니다. (마지막 사진참고)

## 📌 변경 사항 (Changes)
- [X] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
 
feature/details

## 📂 관련 이슈 (Issue)
 close #71 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.

![조아!](https://github.com/user-attachments/assets/74ec8d50-4816-44fe-8548-58c38b86a996)
![태스크조아, ㅋ](https://github.com/user-attachments/assets/47b6ccff-b426-4083-9167-e2f34da44dbe)
![image](https://github.com/user-attachments/assets/8202116f-83a6-4e11-924e-6f5f81fc8db3)