### PR TITLE
[BUG]세부일정 관련 버그 총 수정

### DIFF
--- a/src/components/task/DetailModal.vue
+++ b/src/components/task/DetailModal.vue
@@ -388,11 +388,13 @@ export default {
           await this.fetchTaskDetails(this.workId);
           // 완료 후 바로 조회 모달 갱신을 위한 데이터 다시 불러오기
 
+          if(this.taskDetails.progressRate>0){
           // 상태가 PENDING일 때, PROGRESS로 상태 변경
       if (this.taskDetails.taskStatus === 'PENDING') {
         const taskStore = useTaskStore();
         await taskStore.startTask(this.workId); // 상태를 'PROGRESS'로 변경하는 API 호출
       }
+    }
         } else {
           console.error('세부일정 업데이트 오류:', response.status);
         }

--- a/src/components/task/DetailModal.vue
+++ b/src/components/task/DetailModal.vue
@@ -18,7 +18,8 @@
             <tr>
               <td colspan="2"><strong>세부일정명</strong></td>
               <td colspan="2" v-if="!localEditMode">{{ taskDetails.taskName }}</td>
-              <td colspan="2" v-if="localEditMode"><input v-model="taskDetails.taskName" class="input-field" type="text" />
+              <td colspan="2" v-if="localEditMode"><input v-model="taskDetails.taskName" class="input-field"
+                  type="text" />
               </td>
             </tr>
             <tr>
@@ -72,19 +73,21 @@
             <!-- 선행 일정 -->
             <tr>
               <td><strong>선행 일정</strong></td>
-              <td v-if="taskDetails && taskDetails.prevWorkIds && taskDetails.prevWorkIds.length > 0">{{ taskDetails.prevWorkNames.join(', ') }}</td>
+              <td v-if="taskDetails && taskDetails.prevWorkIds && taskDetails.prevWorkIds.length > 0">{{
+                taskDetails.prevWorkNames.join(', ') }}</td>
               <td v-else>없음</td>
 
               <!-- 후행 일정 -->
               <td><strong>후행 일정</strong></td>
-              <td v-if="taskDetails && taskDetails.nextWorkIds && taskDetails.nextWorkIds.length > 0">{{ taskDetails.nextWorkNames.join(', ') }}</td>
+              <td v-if="taskDetails && taskDetails.nextWorkIds && taskDetails.nextWorkIds.length > 0">{{
+                taskDetails.nextWorkNames.join(', ') }}</td>
               <td v-else>없음</td>
             </tr>
 
             <tr>
               <td colspan="2"><strong>진척률</strong></td>
               <td colspan="2" v-if="!localEditMode">{{ taskDetails.progressRate }}%</td>
-              <td colspan="2" v-if="localEditMode"><input v-model="taskDetails.progressRate" type="number"
+              <td colspan="2" v-if="localEditMode"><input v-model="taskDetails.progressRate" type="number" min="0" max="100"
                   class="input-field" /></td>
             </tr>
             <tr>
@@ -95,8 +98,8 @@
               <td colspan="2"><strong>책임자</strong></td>
               <td colspan="2" v-if="!localEditMode">{{taskDetails.assignees.map(a => a.name).join(', ')}}</td>
               <td colspan="2" v-if="localEditMode">
-                <select v-model="taskDetails.assignees" class="input-field">
-                  <option v-for="user in users" :key="user.id" :value="user.id" >{{ user.name }}</option>
+                <select v-model="taskDetails.assignees" class="input-field" multiple>
+                  <option v-for="user in users" :key="user.id" :value="user.id">{{ user.name }}</option>
                 </select>
               </td>
             </tr>
@@ -116,7 +119,7 @@
         </table>
 
         <!-- 경고 메시지 표시 -->
-<div v-if="errorMessage" class="error-message">{{ errorMessage }}</div>
+        <div v-if="errorMessage" class="error-message">{{ errorMessage }}</div>
 
 
         <div class="modal-footer">
@@ -144,8 +147,8 @@ export default {
   data() {
     return {
       taskDetails: {
-          assignees: [], // 여기서 빈 배열로 초기화
-      participants: []
+        assignees: [], // 여기서 빈 배열로 초기화
+        participants: []
       },
       departments: [], // 부서 목록을 저장하는 변수
       users: [], // 사용자 목록을 저장하는 변수
@@ -160,33 +163,49 @@ export default {
         this.fetchDepartments(); // 부서 목록을 가져옴
       }
     },
-        // 부모 컴포넌트에서 전달된 `isEditMode` 값이 변경되면 반영
+    // 부모 컴포넌트에서 전달된 `isEditMode` 값이 변경되면 반영
     isEditMode(newValue) {
       this.localEditMode = newValue;
     }
   },
-methods: {
-validateForm() {
-  // 각 필드가 비어있는지 체크
+  methods: {
+    validateForm() {
+      // 각 필드가 비어있는지 체크
+      console.log("validateForm 호출");
+      console.log("taskDetails:", this.taskDetails); // taskDetails 값 확인
+      console.log("assignees:", this.taskDetails?.assignees); // 책임자 값 확인
+      console.log("participants:", this.taskDetails?.participants); // 참여자 값 확인
+
+        // 진척률이 비어있거나 유효하지 않은 값일 경우
   if (
-    !this.taskDetails?.taskName ||  // taskDetails가 없으면 오류가 나지 않도록 처리
-    !this.taskDetails?.taskDescription ||
-    !this.taskDetails?.deptId ||
-    !this.taskDetails?.endExpect ||
-    !this.taskDetails?.progressRate ||
-    !this.taskDetails?.assignees ||
-    this.taskDetails.assignees.length === 0 ||
-    !this.taskDetails?.participants ||
-    this.taskDetails.participants.length === 0
-  ) {
-    this.errorMessage = "모든 필수 항목을 입력해주세요.";
-    return false;  // 폼 제출을 막음
+    this.taskDetails?.progressRate === undefined || 
+    this.taskDetails?.progressRate === null || 
+    this.taskDetails?.progressRate === "" || 
+    this.taskDetails?.progressRate < 0 || 
+    this.taskDetails?.progressRate > 100
+  )  {
+    this.errorMessage = "진척률에 0~100 사이의 숫자를 입력해주세요.";
+    return false; // 폼 제출을 막음
   }
 
-  this.errorMessage = "";  // 오류 메시지 초기화
-  return true;
-}
-,
+      if (
+        !this.taskDetails?.taskName ||  // taskDetails가 없으면 오류가 나지 않도록 처리
+        !this.taskDetails?.taskDescription ||
+        !this.taskDetails?.deptId ||
+        !this.taskDetails?.endExpect ||
+        !this.taskDetails?.assignees ||
+        this.taskDetails.assignees.length === 0 ||
+        !this.taskDetails?.participants ||
+        this.taskDetails.participants.length === 0
+      ) {
+        this.errorMessage = "모든 필수 항목을 입력해주세요.";
+        return false;  // 폼 제출을 막음
+      }
+
+      this.errorMessage = "";  // 오류 메시지 초기화
+      return true;
+    }
+    ,
     closeModal() {
       this.errorMessage = "";  // 오류 메시지 초기화
       this.$emit('close-modal'); // 부모 컴포넌트에 모달 닫기 이벤트 전달
@@ -194,7 +213,7 @@ validateForm() {
     openEditModal() {
       this.localEditMode = true; // 수정 모드로 전환
       this.$emit('open-edit-modal');
-      
+
     },
     async fetchTaskDetails(workId) {
       const userStore = useUserStore();
@@ -209,20 +228,34 @@ validateForm() {
         const response = await api.get(`/api/work/detail`, {
           params: { workId }
         });
-          if (response.status === 200) {
+        if (response.status === 200) {
           this.taskDetails = response.data.data;
 
           // 수정 모드일 때, 부서 정보를 기본값으로 설정
-          const selectedDept = this.departments.find(dept => dept.deptId === this.taskDetails.deptId);
-          if (selectedDept) {
-            this.taskDetails.deptName = selectedDept.deptName; // deptName을 부서 이름으로 설정
-            this.fetchUsersByDept(selectedDept.deptName); // 부서 이름으로 사용자 목록 가져오기
+          if (this.localEditMode) { // 수정 모드일 때만 실행
+            const selectedDept = this.departments.find(dept => dept.deptId === this.taskDetails.deptId);
+            if (selectedDept) {
+              this.taskDetails.deptName = selectedDept.deptName;
+              this.fetchUsersByDept(selectedDept.deptName); // 부서명으로 사용자 목록 가져오기
+            }
           }
+
 
           // 수정 모드일 때, 참여자와 담당자 목록을 부서명으로 자동 설정
           if (this.localEditMode) {
-            this.fetchUsersByDept(this.taskDetails.deptName); // 부서명으로 사용자 목록 자동 불러오기
+            // "deep copy" 방식을 사용하여 `assignees`와 `participants`를 업데이트
+            this.taskDetails.assignees = [...this.taskDetails.assignees]; // 배열의 얕은 복사
+            this.taskDetails.participants = [...this.taskDetails.participants]; // 배열의 얕은 복사
+
+            // 수정 모드로 들어갔을 때 기본값을 설정
+            if (this.taskDetails.assignees.length === 0) {
+              // 모든 사용자를 기본 선택
+              this.taskDetails.assignees = this.users.map(user => user.id);
+            }
           }
+
+          // 부서명으로 사용자 목록을 자동으로 불러오기
+          this.fetchUsersByDept(this.taskDetails.deptName);
         } else {
           console.error("세부일정 조회 실패:", response.status);
         }
@@ -230,7 +263,7 @@ validateForm() {
         console.error('세부일정을 불러오는 중 오류가 발생했습니다:', error);
       }
     },
-     async fetchDepartments() {
+    async fetchDepartments() {
       const userStore = useUserStore();
       const token = userStore.accessToken;
 
@@ -251,11 +284,11 @@ validateForm() {
         console.error("부서 데이터를 불러오는 데 실패했습니다:", error);
       }
     },
-     async fetchUsersByDept(deptName) {
-        if (!deptName) {
-    this.errorMessage = "담당 부서를 먼저 선택해주세요.";
-    return;
-  }
+    async fetchUsersByDept(deptName) {
+      if (!deptName) {
+        this.errorMessage = "담당 부서를 먼저 선택해주세요.";
+        return;
+      }
       const userStore = useUserStore();
       const token = userStore.accessToken;
 
@@ -283,61 +316,77 @@ validateForm() {
       const selectedDept = this.departments.find(dept => dept.deptId === this.taskDetails.deptId);
       if (selectedDept) {
         this.fetchUsersByDept(selectedDept.deptName); // 부서 이름을 바탕으로 사용자 목록을 가져옴
-
       }
     }
     ,
+    ///////////// 수정하는 모달
     async saveChanges() {
-        if (!this.validateForm()) {
-          console.log("validateForm 호출")
-    return;
-  }
+
+      // `assignees` 배열에서 `userId`가 없는 객체가 있는지 확인
+      const hasInvalidAssignees = this.taskDetails.assignees.some(a => !a.hasOwnProperty('userId'));
+
+      // assigneeId를 먼저 선언
+      let assigneeId = null;  // 기본값을 null로 설정
+
+      // `userId`가 없는 객체가 있을 경우, `userId`가 있는 객체들을 제외하고, `userId`가 없는 객체들만 남긴다
+      if (hasInvalidAssignees) {
+        // `userId`가 없는 객체들만 필터링하여 남김
+        this.taskDetails.assignees = this.taskDetails.assignees.filter(a => !a.hasOwnProperty('userId'));
+
+        // `userId`가 없는 객체들 중 첫 번째 객체의 `userId`를 assigneeId로 설정
+        if (this.taskDetails.assignees.length > 0) {
+          assigneeId = this.taskDetails.assignees[0]; // 첫 번째 `userId`를 사용
+        }
+      } else {
+        // `userId`가 없는 객체가 없을 경우
+        if (this.taskDetails.assignees.length > 0) {
+          assigneeId = this.taskDetails.assignees[0].userId; // 첫 번째 `userId`를 assigneeId로 설정
+        }
+      }
+
+      // Proxy 객체에서 `userId`가 있는 객체를 삭제
+      const validParticipants = this.taskDetails.participants
+        .filter(p => !p.hasOwnProperty('userId')) // `userId`가 존재하지 않는 객체만 필터링
+        .map(p => {
+          // 여기에 `userId`가 없는 객체만 남음
+          return p;
+        });
+
+      if (!this.validateForm()) {
+        console.log("validateForm 호출")
+        return;
+      }
       this.localEditMode = false; // 저장 후 수정모드 종료
       const userStore = useUserStore();
       const token = userStore.accessToken;
-      const taskStore = useTaskStore();
 
       if (!token) {
         console.error("토큰이 없습니다.");
         return;
       }
 
-  // Proxy 객체에서 `userId`가 있는 객체를 삭제
-  const validParticipants = this.taskDetails.participants
-    .filter(p => !p.hasOwnProperty('userId')) // `userId`가 존재하지 않는 객체만 필터링
-    .map(p => {
-      // 여기에 `userId`가 없는 객체만 남음
-      return p; 
-    });
-
-  console.log("최종 유효한 참여자 목록:", validParticipants);
-  console.log("최종 유효한 참여자 목록:",   this.taskDetails.assignees);
+      console.log("최종 유효한 참여자 목록:", validParticipants);
+      console.log("최종 유효한 책임자 목록:", assigneeId);
 
       const updatedData = {
         name: this.taskDetails.taskName,
         description: this.taskDetails.taskDescription,
         deptId: this.taskDetails.deptId,
-        assigneeId: this.taskDetails.assignees,
-        participantIds: validParticipants , // id 값만 추출
+        assigneeId: assigneeId,
+        participantIds: validParticipants, // id 값만 추출
         expectEnd: this.taskDetails.endExpect,
         progress: this.taskDetails.progressRate,
       };
 
-       try {
+      try {
         const response = await api.put(`/api/detail/update/${this.workId}`, updatedData);
-        
+
         if (response.status === 200) {
           console.log('세부일정 업데이트 성공:', response.data);
-          await this.fetchTaskDetails(this.workId);
-          // 완료 후 바로 조회 모달 갱신을 위한 데이터 다시 불러오기
-      const taskStore = useTaskStore();
-      await taskStore.fetchTaskDetails(this.workId); 
-          const route = useRoute();
-          const parentTaskId = route.params.taskId;
-          await taskStore.fetchTotalProgress(parentTaskId, token); // 총 진척률 가져오기
-
           this.$emit('update-task', this.taskDetails);
           this.$emit('close-modal');
+          await this.fetchTaskDetails(this.workId);
+          // 완료 후 바로 조회 모달 갱신을 위한 데이터 다시 불러오기
         } else {
           console.error('세부일정 업데이트 오류:', response.status);
         }
@@ -356,7 +405,7 @@ validateForm() {
 
       try {
         const response = await api.patch(`/api/detail/${this.workId}/delete`);
-       
+
         if (response.status === 200) {
           console.log('세부일정 삭제 성공:', response.data);
 
@@ -390,14 +439,14 @@ validateForm() {
 }
 
 .modal-content {
-    display: flex;
+  display: flex;
   flex-direction: column;
   overflow-y: auto;
   background-color: #fff;
   padding: 20px;
   border-radius: 10px;
   max-width: 600px;
-  max-height: 750px; 
+  max-height: 750px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
 }
 
@@ -484,5 +533,4 @@ validateForm() {
   font-size: 14px;
   margin-top: 10px;
 }
-
 </style>

--- a/src/components/task/DetailModal.vue
+++ b/src/components/task/DetailModal.vue
@@ -387,6 +387,12 @@ export default {
           this.$emit('close-modal');
           await this.fetchTaskDetails(this.workId);
           // 완료 후 바로 조회 모달 갱신을 위한 데이터 다시 불러오기
+
+          // 상태가 PENDING일 때, PROGRESS로 상태 변경
+      if (this.taskDetails.taskStatus === 'PENDING') {
+        const taskStore = useTaskStore();
+        await taskStore.startTask(this.workId); // 상태를 'PROGRESS'로 변경하는 API 호출
+      }
         } else {
           console.error('세부일정 업데이트 오류:', response.status);
         }

--- a/src/components/task/DetailTab.vue
+++ b/src/components/task/DetailTab.vue
@@ -83,11 +83,9 @@
 </template>
 
 <script>
-import { useRoute } from "vue-router";
 import { useUserStore } from "@/stores/userStore";
 import { useTaskStore } from "@/stores/taskStore"; // Pinia store 임포트
 import TaskModal from "@/components/task/DetailModal.vue"; // 모달 컴포넌트 import
-import { mdiPlayCircle, mdiPauseCircle, mdiCheckCircle } from '@mdi/js'; // MDI 아이콘 import
 import { ref } from 'vue'; // ref 추가 (경고창 처리)
 
 export default {

--- a/src/components/task/DetailTab.vue
+++ b/src/components/task/DetailTab.vue
@@ -104,6 +104,7 @@ export default {
       dialogMessage: ref(''), // 확인 메시지 내용
       itemToUpdate: null, // 확인을 위한 임시 아이템
       newStatus: null, // 새로운 상태값
+      taskId: this.$route.params.taskId,  // route.params에서 taskId를 받음
     };
   },
   computed: {
@@ -117,9 +118,9 @@ export default {
       return taskStore.totalProgress;
     }
   },
-  async mounted() {
-    const route = useRoute();
-    const parentTaskId = route.params.taskId;
+async mounted() {
+    console.log('Task ID from URL:', this.taskId);
+    const parentTaskId = this.taskId;
     const userStore = useUserStore();
     const token = userStore.accessToken;
 
@@ -130,7 +131,8 @@ export default {
     } else {
       console.error("parentTaskId나 token이 없습니다.");
     }
-  },
+  
+},
   methods: {
 confirmAndUpdateStatus(item, newStatus) {
   if (item.status === "COMPLETED") {
@@ -180,9 +182,7 @@ confirmAndUpdateStatus(item, newStatus) {
       // 수정된 항목을 배열에서 업데이트
       this.items.splice(index, 1, updatedTask);
     }
-          // 수정 후 totalProgress 갱신
-      const route = useRoute();
-      const parentTaskId = route.params.taskId;
+    const parentTaskId = this.taskId;
       const userStore = useUserStore();
       const token = userStore.accessToken;
       const taskStore = useTaskStore();

--- a/src/components/task/DetailTab.vue
+++ b/src/components/task/DetailTab.vue
@@ -115,7 +115,8 @@ export default {
       const taskStore = useTaskStore();
       return taskStore.totalProgress;
     }
-  },
+  }
+,
 async mounted() {
     console.log('Task ID from URL:', this.taskId);
     const parentTaskId = this.taskId;

--- a/src/components/task/TaskMainTab.vue
+++ b/src/components/task/TaskMainTab.vue
@@ -144,9 +144,14 @@ const submitForm = async () => {
   console.log(form.value.followingTasks);
   console.log('End Date:', form.value.endDate);  // 추가해서 값을 확인
 
-  // 선행 일정과 후행 일정이 비어 있으면 null로 설정
-  const precedingTasks = form.value.precedingTasks.length > 0 ? form.value.precedingTasks : null;
-  const followingTasks = form.value.followingTasks.length > 0 ? form.value.followingTasks : null;
+    // 선행 일정과 후행 일정이 비어 있으면 빈 배열로 설정하고, 빈 문자열이 포함되면 빈 배열로 처리
+  const precedingTasks = form.value.precedingTasks && form.value.precedingTasks.length > 0
+    ? form.value.precedingTasks.filter(task => task !== "") // 빈 문자열 제외
+    : [];
+  const followingTasks = form.value.followingTasks && form.value.followingTasks.length > 0
+    ? form.value.followingTasks.filter(task => task !== "") // 빈 문자열 제외
+    : [];
+
 
   // 요청 데이터 구성
   const requestData = {
@@ -157,8 +162,8 @@ const submitForm = async () => {
     startBase: form.value.startDate, // 시작 베이스라인
     endBase: form.value.endDate, // 마감 베이스라인
     deptId: form.value.department.deptId, // 부서 ID
-    source: Array.from(form.value.precedingTasks), // Proxy 객체를 배열로 변환
-    target: Array.from(form.value.followingTasks), // Proxy 객체를 배열로 변환
+    source: Array.from(precedingTasks), // Proxy 객체를 배열로 변환
+    target: Array.from(followingTasks), // Proxy 객체를 배열로 변환
     assigneeId: form.value.responsible, // 책임자 ID
     participantIds: Array.from(form.value.participants), // Proxy 객체를 배열로 변환
   };

--- a/src/stores/taskStore.js
+++ b/src/stores/taskStore.js
@@ -76,7 +76,7 @@ async fetchTaskDetails(workId) {
       if (this.taskDetails && this.taskDetails.deptId) {
 
       // 부서 정보 및 사용자 목록 업데이트
-      const selectedDept = this.departments.find(dept => dept.deptId === this.taskDetails.deptId);
+      const selectedDept = this.departments?.find(dept => dept.deptId === this.taskDetails.deptId);
       if (selectedDept) {
         this.taskDetails.deptName = selectedDept.deptName;
         this.fetchUsersByDept(selectedDept.deptName);

--- a/src/views/task/TaskDetail.vue
+++ b/src/views/task/TaskDetail.vue
@@ -22,6 +22,9 @@
                 :taskData="originTaskValue" 
                 :detailList = "detailList"
                 />
+
+                <DetailTab v-show="false" :taskData="originTaskValue" />
+
              </div>
         </template>
 


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)

1. 생성시 선행이나 후행일정 + 버튼눌러서 입력칸 만들고
실제로 선택 안할시에 생성오류떴는데 그부분 버그 고침

2. 세부일정 수정시 진척률에 0~100사이숫자만 받도록 수정함

3.세부일정 수정시 참여자/책임자 등 오류 고침 >>  선택안해도 기존정보 그대로 유지해서 폼제출되게함

4. 세부일정 수정 후에 시작 버튼 안보이던거 고침

5. 진척률이 1~100이면 자동으로 시작버튼에서 진행중버튼으로! 상태값 진행중으로 바꿔주기

6. 태스크 진척률도 세부일정 진척률 수정시 자동 수정시키기

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [X] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)

feature/details

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/9a99b002-3a29-4dac-b5d2-00d51d5efe7f)